### PR TITLE
fix issue with some subtitle parse (srt)

### DIFF
--- a/lib/src/utils/subtitle_parser.dart
+++ b/lib/src/utils/subtitle_parser.dart
@@ -56,7 +56,7 @@ class SubtitleParser extends ISubtitleParser {
     final pattern = regexObject.pattern;
 
     var regExp = RegExp(pattern);
-    var matches = regExp.allMatches(object.data);
+    var matches = regExp.allMatches(object.data.replaceAll('\r', ''));
 
     return _decodeSubtitleFormat(
       matches,


### PR DESCRIPTION
in response to (Srt subtitles parsing don't work issue)
when they send their data in String, there are \r that prevent matches to match. this cuz we receive empty match in response failing the parsing