### PR TITLE
Fix range error for srt format

### DIFF
--- a/lib/src/utils/regexes.dart
+++ b/lib/src/utils/regexes.dart
@@ -91,7 +91,7 @@ class VttRegex extends SubtitleRegexObject {
 /// dart code.
 class SrtRegex extends SubtitleRegexObject {
   static const String _regex =
-      r'(\d+)?\n(?:(\d{1,}):)?(?:(\d{1,2}):)?(\d{1,2})[.,]+(\d+)\s*-->\s*(?:(\d{1,2}):)?(?:(\d{1,2}):)?(\d{1,2}).(\d+)(?:.*(?:\r?(?!\r?).*)*)\n(.*(?:\r?\n(?!\r?\n).*)*)';
+      r'(\d+)?\n(\d{1,}:)?(\d{1,2}:)?(\d{1,2}).(\d+)\s?-->\s?(\d{1,}:)?(\d{1,2}:)?(\d{1,2}).(\d+)(.*(?:\r?(?!\r?).*)*)\n(.*(?:\r?\n(?!\r?\n).*)*)';
   const SrtRegex()
       : super(
           pattern: _regex,


### PR DESCRIPTION
- Fix issue RangeError: Value not in range: 11 when using srt format subtitles